### PR TITLE
Fix bug in FtpBruteForcer

### DIFF
--- a/lib/violent_ruby/ftp_brute_forcer/ftp_brute_forcer.rb
+++ b/lib/violent_ruby/ftp_brute_forcer/ftp_brute_forcer.rb
@@ -101,8 +101,9 @@ module ViolentRuby
 		# @return [Boolean]
 		def able_to_login?(args = {})
 			@ftp.connect(args[:ip], args[:port])
-			@ftp.login(args[:username], args[:password]) 
-			if @ftp.welcome == "230 Login successful.\n"
+			@ftp.login(args[:username], args[:password])
+			# Can be: 230 logged in OR 230 Welcome to blah OR ... 
+			if @ftp.welcome.split(" ")[0] == "230"
 				@ftp.close
 				return true
 			end


### PR DESCRIPTION
Even though the creds are correct FtpBruteForcer tells them as wrong. This happens since different FTP servers may have different welcome messages. The only thing common in those messages is "230" at the beginning.